### PR TITLE
changing '.option' class to use min-height instead of height

### DIFF
--- a/packages/select-pure/src/styles/option.styles.ts
+++ b/packages/select-pure/src/styles/option.styles.ts
@@ -11,8 +11,7 @@ export const optionStyles = css`
     font-family: var(--font-family, inherit);
     font-size: var(--font-size, 14px);
     font-weight: var(--font-weight, 400);
-    height: var(--select-height, 44px);
-    height: var(--select-height, 44px);
+    min-height: var(--select-height, 44px);
     justify-content: flex-start;
     padding: var(--padding, 0 10px);
     width: 100%;


### PR DESCRIPTION
Solves: #51 

The select-height variable now sets the min-height rather than the height of the .option class. This allows the field to grow bigger, if the content requires. Previously it was cutting the content off.

Also, there were two height properties being set to the same thing, I've removed the duplicate.

Thinking about it now, maybe no height should be set here? Should the height just be based on the content + padding?